### PR TITLE
Fix airport coordinate parsing

### DIFF
--- a/app/services/airportResolver.ts
+++ b/app/services/airportResolver.ts
@@ -14,9 +14,15 @@ export function resolveNearestAirport(lat: number, lon: number): ResolvedAirport
   let closestDistance = Number.MAX_SAFE_INTEGER;
 
   for (const airport of airports) {
+    const airportLat = typeof airport.lat === 'string'
+      ? parseFloat(airport.lat)
+      : airport.lat;
+    const airportLon = typeof airport.lon === 'string'
+      ? parseFloat(airport.lon)
+      : airport.lon;
     const distance = geolib.getDistance(
       { latitude: lat, longitude: lon },
-      { latitude: airport.lat, longitude: airport.lon }
+      { latitude: airportLat, longitude: airportLon }
     );
     const km = distance / 1000;
 


### PR DESCRIPTION
## Summary
- parse airport coordinates to numbers before calculating distance

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module 'axios', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685d2547388c8333b453f02907d34c51